### PR TITLE
Improve error handling in Notify

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -159,6 +159,9 @@ func GetServerInformation() (*ServerInfo, error) {
 // Notify sends a notification.
 func Notify(noti *Notification) error {
 	var icon string
+	if busObj == nil {
+		return fmt.Errorf("notification: dbus object is empty")
+	}
 	if noti.icon == "" {
 		icon = AppIcon
 	} else {
@@ -171,7 +174,7 @@ func Notify(noti *Notification) error {
 	err := busObj.Call(busInterface+".Notify", 0, AppName, noti.id, icon, noti.summary, noti.body,
 		noti.actionlist(), noti.hints, int32(noti.timeout.Seconds()*1000)).Store(&noti.id)
 	if err != nil {
-		fmt.Errorf("notification: %w", err)
+		err = fmt.Errorf("notification: %w", err)
 	} else {
 		notifications[noti.id] = noti
 	}


### PR DESCRIPTION
Calling `notification.New` without calling `notification.Init` first results in a runtime panic due to a segmentation fault: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4e0d4a]
```
This can be a rather confusing error for a first-time user of the module that is absent-minded enough to forget to call `Init` (I know it is, I'm one of them ^^).

This PR checks whether `Init` was successfully called (by checking `busObj`) before calling the dbus interface in `Notify`, and returns an error if it's not the case. It also corrects a tiny oversight in the same function, in the handling of the error if `busObj.call` returns an error.

Please edit or ignore this PR if you think this can be better handled.
Thanks for your module!